### PR TITLE
Add Metasploit availability flag to exported plugin filenames

### DIFF
--- a/NessusPluginHosts.py
+++ b/NessusPluginHosts.py
@@ -165,17 +165,14 @@ def write_lines(path: Path, lines, space=False, comma=False):
     if not lines:
         return False
     if space:
-        text = " ".join(lines) + "
-"
+        text = " ".join(lines) + "\\n"
         path.write_text(text, encoding="utf-8")
     elif comma:
-        text = ",".join(lines) + "
-"
+        text = ",".join(lines) + "\\n"
         path.write_text(text, encoding="utf-8")
     else:
         with path.open("w", encoding="utf-8") as fh:
-            fh.writelines(l + "
-" for l in lines)
+            fh.writelines(l + "\\n" for l in lines)
     return True
 
 def main():

--- a/NessusPluginHosts.py
+++ b/NessusPluginHosts.py
@@ -165,14 +165,17 @@ def write_lines(path: Path, lines, space=False, comma=False):
     if not lines:
         return False
     if space:
-        text = " ".join(lines) + "\\n"
+        text = " ".join(lines) + "
+"
         path.write_text(text, encoding="utf-8")
     elif comma:
-        text = ",".join(lines) + "\\n"
+        text = ",".join(lines) + "
+"
         path.write_text(text, encoding="utf-8")
     else:
         with path.open("w", encoding="utf-8") as fh:
-            fh.writelines(l + "\\n" for l in lines)
+            fh.writelines(l + "
+" for l in lines)
     return True
 
 def main():

--- a/NessusPluginHosts.py
+++ b/NessusPluginHosts.py
@@ -87,10 +87,9 @@ def parse_nessus_file(filename, plugin_id, omit_ports=False):
 def build_index_stream(filename, include_ports=True):
     """
     Single-pass streaming index:
-      - plugins: pid -> {name, severity_int, severity_label, msf: bool}
+      - plugins: pid -> {name, severity_int, severity_label, msf}
       - plugin_hosts: pid -> set(host entries)
     Severity is derived from <cvss3_base_score>, falling back to <cvss_base_score> when missing.
-    MSF availability is True if <exploit_framework_metasploit> is 'true'/'yes'/'1' for any ReportItem of the plugin.
     """
     plugins = {}
     plugin_hosts = defaultdict(set)
@@ -115,10 +114,10 @@ def build_index_stream(filename, include_ports=True):
                     cvss = elem.findtext("cvss_base_score")
                 sev_int = cvss_to_sev(cvss)
 
-                # Metasploit availability via explicit framework flag
+                # Metasploit availability flag
                 msf_flag = truthy(elem.findtext("exploit_framework_metasploit"))
 
-                # Plugin name & highest severity; merge msf flag
+                # Plugin name & highest severity
                 pname = (elem.attrib.get("pluginName") or "").strip()
                 existing = plugins.get(pid)
                 if existing is None:
@@ -129,14 +128,14 @@ def build_index_stream(filename, include_ports=True):
                         "msf": msf_flag,
                     }
                 else:
-                    # Keep highest severity
+                    # keep highest severity
                     if sev_int > existing["severity_int"]:
                         existing["severity_int"] = sev_int
                         existing["severity_label"] = severity_label_from_int(sev_int)
-                    # Merge MSF (any True wins)
+                    # merge msf (any True wins)
                     if msf_flag:
                         existing["msf"] = True
-                    # Fill name if previously blank
+                    # fill name if previously blank
                     if not existing.get("name") and pname:
                         existing["name"] = pname
 
@@ -165,14 +164,14 @@ def write_lines(path: Path, lines, space=False, comma=False):
     if not lines:
         return False
     if space:
-        text = " ".join(lines) + "\\n"
+        text = " ".join(lines) + "\n"
         path.write_text(text, encoding="utf-8")
     elif comma:
-        text = ",".join(lines) + "\\n"
+        text = ",".join(lines) + "\n"
         path.write_text(text, encoding="utf-8")
     else:
         with path.open("w", encoding="utf-8") as fh:
-            fh.writelines(l + "\\n" for l in lines)
+            fh.writelines(l + "\n" for l in lines)
     return True
 
 def main():
@@ -231,7 +230,7 @@ def main():
             plugins, plugin_hosts = build_index_stream(file, include_ports=(not args.no_port))
 
             if args.directory and not in_export_mode:
-                print(f"\\n===== Plugins in {os.path.basename(file)} =====")
+                print(f"\n===== Plugins in {os.path.basename(file)} =====")
 
             if not plugins:
                 if not in_export_mode:
@@ -275,7 +274,7 @@ def main():
                     if written:
                         print(f"Wrote {out_path}")
                 else:
-                    name = meta["name"].replace("\\n", " ").replace("\\r", " ").strip()
+                    name = meta["name"].replace("\n", " ").replace("\r", " ").strip()
                     print(f"{pid},{meta['severity_int']},{meta['severity_label']},{name}")
         return
 
@@ -288,7 +287,7 @@ def main():
         matches = parse_nessus_file(file, args.plugin_id, args.no_port)
 
         if args.directory:
-            print(f"\\n===== Results from {os.path.basename(file)} =====")
+            print(f"\n===== Results from {os.path.basename(file)} =====")
 
         if matches:
             if args.space_delim:
@@ -296,7 +295,7 @@ def main():
             elif args.comma_delim:
                 print(",".join(matches))
             else:
-                print("\\n".join(matches))
+                print("\n".join(matches))
         else:
             print(f"No matches found for plugin ID {args.plugin_id}.")
 


### PR DESCRIPTION
This update modifies the --export-plugin-hosts functionality so that exported filenames now reflect if a Metasploit module is available for the plugin. The script checks each <ReportItem> for the <exploit_framework_metasploit> element set to true. If present, -MSF is appended to the corresponding export filename (e.g., 125265_Oracle_WebLogic_RCE-MSF.txt).

This enhancement makes it easier to quickly identify vulnerabilities with Metasploit coverage directly from the exported host/plugin file list, without needing to cross-reference Nessus reports manually.